### PR TITLE
fix: initialise header fields and clean up class declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The classes carried no version marker before this file existed; history prior to
 
 ### Added
 
+- `examples/minimal_cv.tex` — the smallest CV the template can produce, and the
+  regression test for the omitted-field fix below.
 - `Makefile` (`make test` / `build` / `lint` / `clean`) compiling every example
   with two `lualatex` passes, plus a page-count assertion per example — the
   layout is absolutely positioned, so a broken change often still compiles.
@@ -23,6 +25,21 @@ The classes carried no version marker before this file existed; history prior to
 
 ### Fixed
 
+- **Omitting a header field no longer errors.** Fields such as `\cvnumberphone`
+  were self-redefining macros with no initial value, so leaving one out (rather
+  than calling it with `{}`) left a macro still expecting an argument and failed
+  with `Argument of \cvnumberphone has an extra }`. Setters now store into
+  separate storage macros that start empty. The public API is unchanged.
+- `\ifblank` (used by `\subsectionright`) resolved only through a transitive
+  dependency; `etoolbox` is now required explicitly and listed in the README.
+- `\ProvidesClass` now precedes `\LoadClass`, as LaTeX2e requires, and both
+  classes carry a real version instead of their 2019 creation date.
+- Both classes used `\usepackage` for `fontawesome`; a class must use
+  `\RequirePackage`.
+
 ### Deprecated
 
 ### Removed
+
+- `ragged2e`, `titlesec` and `multirow` were loaded by the classes but never
+  used, and are no longer required.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # a LaTeX document class, and the examples between them exercise every documented
 # command, both languages, both letter conventions and the multi-page path.
 #
-# latexmk must run from the repo root: the classes live here, and the examples
+# lualatex must run from the repo root: the classes live here, and the examples
 # reference pictures/ relative to the root rather than to examples/.
 
 SHELL    := /bin/bash
@@ -33,6 +33,7 @@ PASSES := 2
 # onto an extra one. A clean exit code alone is not evidence; this is.
 # Adding an example without adding its expected count here fails `make test`.
 PAGES_example_cv           := 1
+PAGES_minimal_cv           := 1
 PAGES_example_cover_letter := 1
 PAGES_Arthur_Bernard_CV_En := 1
 PAGES_Arthur_Bernard_CV_Fr := 1

--- a/README.md
+++ b/README.md
@@ -215,15 +215,13 @@ ___
   - fontspec;   
   - ClearSans;   
   - fontawesome;   
-  - ragged2e;   
   - parskip;   
   - hyperref;   
   - textpos;   
-  - titlesec;   
   - tikz;   
   - xcolor;   
-  - multirow;   
   - xargs;   
+  - etoolbox;   
   - tcolorbox;   
   - enumitem;   
   - ifthen.   

--- a/arthur-cover-letter.cls
+++ b/arthur-cover-letter.cls
@@ -4,8 +4,8 @@
 % @Last modified by: ArthurBernard
 % @Last modified time: 2020-01-29 19:08:37
 \NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{arthur-cover-letter}[2026/08/27 v1.0.0 Custom cover letter with header class]
 \LoadClass{article}
-\ProvidesClass{arthur-cover-letter}[2019/08/06 Custom cover letter with header class]
 
 % TODO : Add option several pages
 
@@ -13,10 +13,11 @@
 %%  Load packages  %%
 %%=================%%
 
+% A class must use \RequirePackage, not \usepackage; ragged2e was loaded but
+% never used.
 \RequirePackage[quiet]{fontspec}
 \RequirePackage[sfdefault]{ClearSans} % Police
-\usepackage{fontawesome}              % Icons
-\RequirePackage{ragged2e}
+\RequirePackage{fontawesome}          % Icons
 \RequirePackage{parskip}
 \RequirePackage[hidelinks]{hyperref}  % Hyperlink
 \RequirePackage[absolute,overlay]{textpos} % Set text boxes
@@ -42,15 +43,27 @@
 %%  Information  %%
 %%===============%%
 
-% Set linkedin, github, mail, phone, site, address, years old, picture, name and title letter commands
-\newcommand{\cvlinkedin}[1]{\renewcommand{\cvlinkedin}{#1}}
-\newcommand{\cvgithub}[1]{\renewcommand{\cvgithub}{#1}}
-\newcommand{\cvmail}[1]{\renewcommand{\cvmail}{#1}}
-\newcommand{\cvnumberphone}[1]{\renewcommand{\cvnumberphone}{#1}}
-\newcommand{\cvsite}[1]{\renewcommand{\cvsite}{#1}}
-\newcommand{\profilepic}[1]{\renewcommand{\profilepic}{#1}}
-\newcommand{\cvname}[1]{\renewcommand{\cvname}{#1}}
-\newcommand{\cvjobtitle}[1]{\renewcommand{\cvjobtitle}{#1}}
+% Declare a header field: \cv@declarefield{cvmail}{mail} creates the public
+% setter \cvmail{...}, which stores its argument in \cv@mail. The storage macro
+% is initialised *empty*, so simply omitting a field is exactly as safe as
+% calling it with {}. Before this, an omitted field left a macro still expecting
+% an argument, and the \equal test in \makeprofile then failed with an
+% unreadable error -- the most likely first-run failure for a new user.
+\newcommand{\cv@declarefield}[2]{%
+  \expandafter\newcommand\csname cv@#2\endcsname{}%
+  \expandafter\newcommand\csname #1\endcsname[1]{%
+    \expandafter\renewcommand\csname cv@#2\endcsname{##1}%
+  }%
+}
+
+\cv@declarefield{cvname}{name}
+\cv@declarefield{cvjobtitle}{jobtitle}
+\cv@declarefield{cvlinkedin}{linkedin}
+\cv@declarefield{cvgithub}{github}
+\cv@declarefield{cvmail}{mail}
+\cv@declarefield{cvnumberphone}{numberphone}
+\cv@declarefield{cvsite}{site}
+\cv@declarefield{profilepic}{profilepic}
 
 %%==========%%
 %%  Header  %%
@@ -84,44 +97,44 @@
       \renewcommand{\arraystretch}{1.4}
       \begin{tabular}{p{1.1cm} @{\hskip 0.3cm}p{6.2cm}}
         % Set phone
-        \ifthenelse{\equal{\cvnumberphone}{}}{}{
+        \ifthenelse{\equal{\cv@numberphone}{}}{}{
           {$
             \begin{array}{l}
               \hspace{4mm} \textnormal{\LARGE \faMobile} 
             \end{array}
-          $} & \large\cvnumberphone\\
+          $} & \large\cv@numberphone\\
         }
         % Set site
-        \ifthenelse{\equal{\cvsite}{}}{}{
+        \ifthenelse{\equal{\cv@site}{}}{}{
           {$
             \begin{array}{l}
               \hspace{2.8mm} \textnormal{\textcolor{test}{\Large \faGlobe}}
             \end{array}
-          $} & \href{http://\cvsite}{\large\cvsite} \\
+          $} & \href{http://\cv@site}{\large\cv@site} \\
         }
         % Set eMail
-        \ifthenelse{\equal{\cvmail}{}}{}{
+        \ifthenelse{\equal{\cv@mail}{}}{}{
           {$
             \begin{array}{l}
               \hspace{2.5mm} \textnormal{\Large \textcolor{yt}{\faEnvelopeO}}
             \end{array}
-          $} & \href{mailto:\cvmail}{\large\cvmail} \\
+          $} & \href{mailto:\cv@mail}{\large\cv@mail} \\
         }
         % Set LinkendIn
-        \ifthenelse{\equal{\cvlinkedin}{}}{}{
+        \ifthenelse{\equal{\cv@linkedin}{}}{}{
           {$
             \begin{array}{l}
               \hspace{3mm} \textnormal{\Large \textcolor{linkedin}{\faLinkedin}}
             \end{array}
-          $} & \href{https://www.linkedin.com\cvlinkedin}{\large\cvlinkedin} \\
+          $} & \href{https://www.linkedin.com\cv@linkedin}{\large\cv@linkedin} \\
         }
         % Set GitHub
-        \ifthenelse{\equal{\cvgithub}{}}{}{
+        \ifthenelse{\equal{\cv@github}{}}{}{
           {$
             \begin{array}{l}
               \hspace{3mm} \textnormal{\Large \faGithub}
             \end{array}
-          $} & \href{https://www.github.com/\cvgithub}{\large\cvgithub} \\
+          $} & \href{https://www.github.com/\cv@github}{\large\cv@github} \\
         }
       
       \end{tabular}
@@ -135,11 +148,11 @@
 
       % Set name and title letter
       \vspace{3mm}
-      {\hspace{0mm}\Huge\color{maincolor}\cvname}
+      {\hspace{0mm}\Huge\color{maincolor}\cv@name}
       
       \vspace{5mm}
 
-      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cvjobtitle}}
+      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cv@jobtitle}}
 
     \end{minipage}
 
@@ -152,9 +165,9 @@
   \begin{textblock}{3.5}(17.25, 0.25)
 
     % Display picture and box if provided else nothing
-    \ifthenelse{\equal{\profilepic}{}}{}{
+    \ifthenelse{\equal{\cv@profilepic}{}}{}{
       \begin{tikzpicture}[remember picture,overlay]
-        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\profilepic}};
+        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\cv@profilepic}};
         \draw[line width=0.5mm, boxcolor] (0.20cm, 0.05cm) -- + (3.15cm, 0) -- + (3.15cm, -3.15cm) -- + (0,-3.15cm) -- cycle;
       \end{tikzpicture}
     }

--- a/arthur-cv.cls
+++ b/arthur-cv.cls
@@ -4,25 +4,27 @@
 % @Last modified by: ArthurBernard
 % @Last modified time: 2023-12-08 10:30:26
 \NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{arthur-cv}[2026/08/27 v1.0.0 Custom CV class]
 \LoadClass{article}
-\ProvidesClass{arthur-cv}[2019/07/31 Custom CV class]
 
 %%=================%%
 %%  Load packages  %%
 %%=================%%
 
+% A class must use \RequirePackage, not \usepackage. ragged2e, titlesec and
+% multirow were loaded but never used, and are dropped. etoolbox is now loaded
+% explicitly: \subsectionright uses \ifblank, which until now only resolved
+% through a transitive dependency of tcolorbox/xargs.
 \RequirePackage[quiet]{fontspec}
 \RequirePackage[sfdefault]{ClearSans} % Police
-\usepackage{fontawesome}              % Icons
-\RequirePackage{ragged2e}
+\RequirePackage{fontawesome}          % Icons
 \RequirePackage{parskip}
 \RequirePackage[hidelinks]{hyperref}  % Hyperlink
 \RequirePackage[absolute,overlay]{textpos} % Set text boxes
-\RequirePackage{titlesec}             % Structure
 \RequirePackage{tikz}                 % Graphic
 \RequirePackage{xcolor}               % Colors
-\RequirePackage{multirow}             % Join rows in tabular
 \RequirePackage{xargs}                % Multiple optional args
+\RequirePackage{etoolbox}             % \ifblank, used by \subsectionright
 \RequirePackage{tcolorbox}            % Colored box
 \RequirePackage{enumitem}             % Customize item
 \RequirePackage{ifthen}               % Conditions
@@ -47,17 +49,29 @@
 %%  Information  %%
 %%===============%%
 
-% Set linkedin, github, mail, phone, site, address, years old, pictures, name and tilte cv commands
-\newcommand{\cvlinkedin}[1]{\renewcommand{\cvlinkedin}{#1}}
-\newcommand{\cvgithub}[1]{\renewcommand{\cvgithub}{#1}}
-\newcommand{\cvmail}[1]{\renewcommand{\cvmail}{#1}}
-\newcommand{\cvnumberphone}[1]{\renewcommand{\cvnumberphone}{#1}}
-\newcommand{\cvaddress}[1]{\renewcommand{\cvaddress}{#1}}
-\newcommand{\cvsite}[1]{\renewcommand{\cvsite}{#1}}
-\newcommand{\profilepic}[1]{\renewcommand{\profilepic}{#1}}
-\newcommand{\cvname}[1]{\renewcommand{\cvname}{#1}}
-\newcommand{\cvjobtitle}[1]{\renewcommand{\cvjobtitle}{#1}}
-\newcommand{\cvyearsold}[1]{\renewcommand{\cvyearsold}{#1}}
+% Declare a header field: \cv@declarefield{cvmail}{mail} creates the public
+% setter \cvmail{...}, which stores its argument in \cv@mail. The storage macro
+% is initialised *empty*, so simply omitting a field is exactly as safe as
+% calling it with {}. Before this, an omitted field left a macro still expecting
+% an argument, and the \equal test in \makeprofile then failed with an
+% unreadable error -- the most likely first-run failure for a new user.
+\newcommand{\cv@declarefield}[2]{%
+  \expandafter\newcommand\csname cv@#2\endcsname{}%
+  \expandafter\newcommand\csname #1\endcsname[1]{%
+    \expandafter\renewcommand\csname cv@#2\endcsname{##1}%
+  }%
+}
+
+\cv@declarefield{cvname}{name}
+\cv@declarefield{cvjobtitle}{jobtitle}
+\cv@declarefield{cvlinkedin}{linkedin}
+\cv@declarefield{cvgithub}{github}
+\cv@declarefield{cvmail}{mail}
+\cv@declarefield{cvnumberphone}{numberphone}
+\cv@declarefield{cvaddress}{address}
+\cv@declarefield{cvsite}{site}
+\cv@declarefield{cvyearsold}{yearsold}
+\cv@declarefield{profilepic}{profilepic}
 
 %%==========%%
 %%  Header  %%
@@ -96,44 +110,44 @@
       \renewcommand{\arraystretch}{1.4}
       \begin{tabular}{p{1.1cm} @{\hskip 0.3cm}p{6.2cm}}
         % Set phone
-        \ifthenelse{\equal{\cvnumberphone}{}}{}{
+        \ifthenelse{\equal{\cv@numberphone}{}}{}{
           {$
             \begin{array}{l}
               \hspace{4mm} \textnormal{\LARGE \faMobile} 
             \end{array}
-          $} & \large\cvnumberphone\\
+          $} & \large\cv@numberphone\\
         }
         % Set site
-        \ifthenelse{\equal{\cvsite}{}}{}{
+        \ifthenelse{\equal{\cv@site}{}}{}{
           {$
             \begin{array}{l}
               \hspace{2.8mm} \textnormal{\textcolor{test}{\Large \faGlobe}}
             \end{array}
-          $} & \href{http://\cvsite}{\large\cvsite} \\
+          $} & \href{http://\cv@site}{\large\cv@site} \\
         }
         % Set eMail
-        \ifthenelse{\equal{\cvmail}{}}{}{
+        \ifthenelse{\equal{\cv@mail}{}}{}{
           {$
             \begin{array}{l}
               \hspace{2.5mm} \textnormal{\Large \textcolor{yt}{\faEnvelopeO}}
             \end{array}
-          $} & \href{mailto:\cvmail}{\large\cvmail} \\
+          $} & \href{mailto:\cv@mail}{\large\cv@mail} \\
         }
         % Set LinkendIn
-        \ifthenelse{\equal{\cvlinkedin}{}}{}{
+        \ifthenelse{\equal{\cv@linkedin}{}}{}{
           {$
             \begin{array}{l}
               \hspace{3mm} \textnormal{\Large \textcolor{linkedin}{\faLinkedin}}
             \end{array}
-          $} & \href{https://www.linkedin.com\cvlinkedin}{\large\cvlinkedin} \\
+          $} & \href{https://www.linkedin.com\cv@linkedin}{\large\cv@linkedin} \\
         }
         % Set GitHub
-        \ifthenelse{\equal{\cvgithub}{}}{}{
+        \ifthenelse{\equal{\cv@github}{}}{}{
           {$
             \begin{array}{l}
               \hspace{3mm} \textnormal{\Large \faGithub}
             \end{array}
-          $} & \href{https://www.github.com/\cvgithub}{\large\cvgithub} \\
+          $} & \href{https://www.github.com/\cv@github}{\large\cv@github} \\
         }
       
       \end{tabular}
@@ -147,17 +161,17 @@
 
       % Set name and title CV
       \vspace{3mm}
-      {\hspace{0mm}\Huge\color{maincolor}\cvname}
+      {\hspace{0mm}\Huge\color{maincolor}\cv@name}
       
       \vspace{5mm}
 
-      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cvjobtitle}}
+      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cv@jobtitle}}
 
       \vspace{3mm}
 
-      {\hspace{0mm}\cvaddress}
+      {\hspace{0mm}\cv@address}
 
-      {\hspace{0mm}\cvyearsold}
+      {\hspace{0mm}\cv@yearsold}
 
     \end{minipage}
 
@@ -170,9 +184,9 @@
   \begin{textblock}{3.5}(17.25, 0.25)
 
     % Display picture and box if provided else nothing
-    \ifthenelse{\equal{\profilepic}{}}{}{
+    \ifthenelse{\equal{\cv@profilepic}{}}{}{
       \begin{tikzpicture}[remember picture,overlay]
-        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\profilepic}};
+        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\cv@profilepic}};
         \draw[line width=0.5mm, boxcolor] (0.20cm, 0.05cm) -- + (3.15cm, 0) -- + (3.15cm, -3.15cm) -- + (0,-3.15cm) -- cycle;
       \end{tikzpicture}
     }

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -20,8 +20,9 @@ public API — see the invariants in `CLAUDE.md`.
 ```
 arthur-cv.cls              # the CV class (~275 lines)
 arthur-cover-letter.cls    # the cover-letter class (~245 lines)
-examples/                  # 5 .tex + committed reference .pdf
-  example_cv.tex           #   minimal skeleton (John Doe)
+examples/                  # 6 .tex + committed reference .pdf
+  example_cv.tex           #   skeleton (John Doe)
+  minimal_cv.tex           #   smallest possible CV; omits most header fields
   example_cover_letter.tex #   minimal letter
   Arthur_Bernard_CV_En.tex #   real EN CV — no photo/age/address
   Arthur_Bernard_CV_Fr.tex #   real FR CV — with photo/age/address

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -36,8 +36,12 @@ example); the class only provides the commands used *inside* them.
 
 A two-`minipage` row: a `tabular` of contact rows on the left, name + job title
 on the right, then a separate `textblock` for the photo with a tikz-drawn frame.
-Each contact row is guarded by `\ifthenelse{\equal{\cvfoo}{}}{}{...}` so unset
-fields vanish.
+
+Each public setter (`\cvmail{...}`) is built by `\cv@declarefield` and stores
+its argument in a private macro (`\cv@mail`) that is **initialised empty**.
+`\makeprofile` reads the private macro and guards each row with
+`\ifthenelse{\equal{\cv@foo}{}}{}{...}`, so a field that is unset — whether
+passed `{}` or omitted entirely — renders nothing.
 
 Two implementation notes:
 
@@ -82,15 +86,10 @@ roadmap.
   by grabbing `#1#2#3`. A title shorter than three tokens, or starting with a
   group/macro, eats the tokens that follow. All current examples have long
   titles, so it never fires.
-- **Header fields are self-redefining macros**
-  (`\newcommand{\cvname}[1]{\renewcommand{\cvname}{#1}}`) with **no default**.
-  Omitting a field entirely — as opposed to calling it with `{}` — leaves a
-  1-argument macro that `\equal` then mis-expands, producing a cryptic error.
-- **`\ifblank` is used without loading `etoolbox`**; it arrives transitively via
-  `tcolorbox`/`xargs`. It is also absent from the README's dependency list.
-- **`titlesec`, `multirow` and `ragged2e` are loaded but never used.**
-- **`\usepackage{fontawesome}`** appears inside a `.cls` (should be
-  `\RequirePackage`), and `\LoadClass` runs *before* `\ProvidesClass`.
+- **`\subsectionleft` takes two *mandatory* arguments**, but the examples often
+  pass one. That works only by accident: `\newcommand` builds `\long` macros, so
+  the `\par` from the following blank line silently becomes the second argument.
+  Pass `{}` explicitly.
 - **No class options** are declared (`\DeclareOption`/`\ProcessOptions` are
   absent), so colour themes can only be applied by re-`\definecolor`ing in the
   user preamble.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -81,3 +81,30 @@ enforces it.
 **Rejected:** diffing rendered pages against committed reference images. More
 faithful, but it makes every intentional cosmetic change a binary-blob churn in
 a repo already carrying 3.8 MB of JPEGs.
+
+### 2026-08-27 — Header fields store into private macros
+
+**Context.** `\cvmail` and friends were self-redefining macros:
+`\newcommand{\cvmail}[1]{\renewcommand{\cvmail}{#1}}`. Calling one replaced it
+with its value. But a field never called stayed a *one-argument* macro, so
+`\makeprofile`'s `\ifthenelse{\equal{\cvmail}{}}` expanded a macro still hunting
+for an argument and died with `Argument of \cvnumberphone has an extra }` — a
+message that points nowhere near the actual mistake. Omitting a field is the
+obvious thing for a newcomer to do, so this was the most likely first-run
+failure.
+
+**Decision.** Split setter from storage: `\cv@declarefield{cvmail}{mail}` builds
+the public setter `\cvmail{...}`, which writes into `\cv@mail`. Storage macros
+are initialised empty, so an omitted field and a `{}` field are identical.
+`\makeprofile` reads the private macros.
+
+**The public API is unchanged** — `\cvmail{...}` still works exactly as
+documented, which the frozen-API invariant requires. Verified by rendering every
+pre-existing example before and after at 100 dpi: all six pages are
+byte-identical PNGs. `examples/minimal_cv.tex` is the regression test; it fails
+to compile against the previous class and succeeds against this one.
+
+*Considered and rejected:* keeping the self-redefining idiom and making
+`\makeprofile` tolerate an unset one-argument macro. There is no clean way to
+test that from `\ifthenelse`, and the fragility would remain for anyone reading
+a field directly.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,12 +10,16 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   `\subsectionright`), multi-page via `\newcvpage`.
 - **`arthur-cover-letter`** — same header, FR and EN address/recipient
   conventions, `coverletter` environment with subject/opening/closing/signing.
-- **Five examples** covering both classes, both languages, both conventions and
-  the multi-page path. All are the real documents the author uses.
+- **Six examples** covering both classes, both languages, both conventions, the
+  multi-page path and the omitted-field edge. Four are the author's real
+  documents; `example_cv` and `minimal_cv` are skeletons.
 - **Colour theming** by redefining five colours in the user preamble; four ready
   themes (green/red/grey/yellow) documented in the root `README.md`.
 - **Dev loop adopted (2026-08-27)** — `develop` branch, `.claude/` config,
   canonical hook copies, this `doc/dev/` pack, `CHANGELOG.md`.
+- **Class hygiene (2026-08-27)** — header fields initialised (omitting one is
+  safe), `etoolbox` required explicitly, identification before `\LoadClass`,
+  unused packages dropped, classes versioned `v1.0.0`.
 
 ## Known gaps
 
@@ -23,10 +27,6 @@ Ordered by how likely they are to bite someone. Details in
 [`02-architecture.md`](02-architecture.md); open items in
 [`07-roadmap.md`](07-roadmap.md).
 
-- **Omitting a header field errors cryptically** instead of rendering nothing —
-  the fields have no default. Most likely first-run failure for a new user.
-- **`\ifblank` used without `etoolbox` loaded** — works only via a transitive
-  dependency, and is missing from the README's package list.
 - **`\@sectioncolor` eats tokens** on `\section` titles shorter than three
   tokens or starting with a macro/group.
 - **The left/right widths are split across the class and the user's `.tex`**, so
@@ -35,6 +35,8 @@ Ordered by how likely they are to bite someone. Details in
   drifted.
 - **No page-break support** — overflowing content silently runs off the page.
   This is by design (see `03-decisions.md`), but it is a real usability edge.
+- **`\subsectionleft` needs both braces**; passing one silently feeds it a
+  `\par`. Harmless in practice, but it explains uneven item spacing.
 - **`fontawesome` 4.7** is frozen upstream.
 
 ## Deferred deliberately

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -16,20 +16,15 @@ here: git log + `CHANGELOG.md` are authoritative for *what* shipped,
 
 ## 1. Correctness & robustness
 
-- [ ] Initialise every header field to empty at class load, so **omitting** a
-      field renders nothing instead of erroring. Currently only calling it with
-      `{}` is safe. (`02-architecture.md` § Known fragilities)
-- [ ] `\RequirePackage{etoolbox}` explicitly — `\ifblank` currently resolves only
-      through a transitive dependency — and add it to the README package list.
 - [ ] Make `\@sectioncolor` safe for `\section` titles shorter than three tokens
       or starting with a macro/group. Currently it grabs `#1#2#3` blindly.
 
-## 2. Class conformance
-
-- [ ] Move `\ProvidesClass` above `\LoadClass`, turn the stray
-      `\usepackage{fontawesome}` into `\RequirePackage`, drop the unused
-      `titlesec` / `multirow` / `ragged2e`, and give the classes a real version
-      in `\ProvidesClass[...]` (currently frozen at the 2019 creation date).
+- [ ] Make `\subsectionleft`'s second argument genuinely optional, or document
+      that both braces are required. Today `\subsectionleft{Skill}` compiles only
+      because `\newcommand` is `\long` and the following blank line's `\par`
+      lands in the second argument. Note the API is frozen: switching to a
+      bracketed optional argument would break every existing fork, so this is a
+      documentation fix unless a compatible form is found.
 
 ## 3. API & ergonomics
 

--- a/examples/minimal_cv.tex
+++ b/examples/minimal_cv.tex
@@ -1,0 +1,54 @@
+% The smallest CV this template can produce, and a regression test.
+%
+% Every header field except the name and the email is OMITTED here — not set to
+% {}, left out entirely. That used to fail with "Argument of \cvnumberphone has
+% an extra }", because an unset field was still a macro expecting an argument.
+% Header fields now start empty, so omitting one renders nothing.
+%
+% Compile from the repository root:
+%   lualatex -output-directory=build examples/minimal_cv.tex
+
+\documentclass[a4paper]{arthur-cv}
+
+\usepackage[english]{babel}
+
+\cvname{Jane Roe}
+\cvmail{jane.roe@example.org}
+\cvjobtitle{Junior Developer}
+
+\begin{document}
+  \makeprofile
+
+  \begin{textblock}{20.5}(0.25, 3.5)
+
+    \begin{minipage}[t]{0.37\textwidth}
+
+      \sectionleft{Skills}
+        % Both braces are required. Passing only the first happens to work, but
+        % it silently feeds \par into the second argument — pass {} instead.
+        \subsectionleft{Python}{}
+
+        \subsectionleft{SQL}{}
+
+      \sectionleft{Languages}
+        \subsectionleft{English}{(native)}
+
+        \subsectionleft{French}{(fluent)}
+
+    \end{minipage}\hfill\begin{minipage}[t]{0.61\textwidth}
+
+      \section{Experience}
+        \begin{rightenv}
+          \subsectionright{2024 – Present}{Developer}[at \textbf{Some Company}][Paris, France]{Building and maintaining internal tools.}
+        \end{rightenv}
+
+      \section{Education}
+        \begin{rightenv}
+          \subsectionright{2021 – 2024}[BSc]{Computer Science}[at \textbf{A University}][Lyon, France]{}
+        \end{rightenv}
+
+    \end{minipage}
+
+  \end{textblock}
+
+\end{document}


### PR DESCRIPTION
## The bug

Omitting a header field — the obvious thing for a newcomer to do — failed with:

```
Argument of \cvnumberphone has an extra }.
```

which points nowhere near the actual mistake. The fields were self-redefining
macros (`\newcommand{\cvmail}[1]{\renewcommand{\cvmail}{#1}}`) with no initial
value, so a field never called stayed a *one-argument* macro that
`\makeprofile`'s `\equal` test then mis-expanded. Only calling it with `{}` was
safe, and nothing said so.

## The fix

Setters now write into private storage macros initialised empty, built by
`\cv@declarefield{cvmail}{mail}`. An omitted field and a `{}` field are now
identical. **The public API is untouched**, as the frozen-API invariant requires.

## Also in this hygiene pass

- `\ProvidesClass` now precedes `\LoadClass`, as LaTeX2e requires; both classes
  carry `v1.0.0` instead of their 2019 creation date.
- `\usepackage{fontawesome}` → `\RequirePackage` (a class must not `\usepackage`).
- `etoolbox` required explicitly — `\ifblank` resolved only transitively through
  `tcolorbox`/`xargs` — and added to the README dependency list.
- `ragged2e`, `titlesec` and `multirow` were loaded but never used; dropped.

## Verification

- `examples/minimal_cv.tex` is the regression test: it **fails** against the
  previous class and compiles against this one.
- Every pre-existing example renders **byte-identically** at 100 dpi before and
  after (6 pages compared), so the refactor is visually inert.

## Found but deliberately not fixed

`\subsectionleft` takes two *mandatory* arguments and the examples often pass
one. That works only because `\newcommand` builds `\long` macros and the next
blank line's `\par` lands in the second argument. Fixing it properly would mean
a bracketed optional argument, which breaks every existing fork — so it's
recorded in the roadmap as a documentation fix.

---
📚 2/6. Base: `chore/claude-dev-loop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)