### PR TITLE
feat: colour themes as class options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The classes carried no version marker before this file existed; history prior to
 
 ### Added
 
+- **Colour themes as class options** — `\documentclass[green]{arthur-cv}`.
+  `blue` (default), `green`, `red`, `grey`/`gray`, `yellow`; the same names work
+  on `arthur-cover-letter`. Redefining the colours in your own preamble still
+  works and still takes precedence. Unrecognised options (`11pt`, …) are passed
+  through to `article` as before.
 - `examples/minimal_cv.tex` — the smallest CV the template can produce, and the
   regression test for the omitted-field fix below.
 - `Makefile` (`make test` / `build` / `lint` / `clean`) compiling every example

--- a/README.md
+++ b/README.md
@@ -32,53 +32,35 @@ ___
 
 ## Customized colors
 
-The default theme color of CV and cover letter is different kind of blue, but you can freely custom themes color, see below some non-exhaustive examples:
-
-![Colored_Examples](https://github.com/ArthurBernard/Arthur-CV-LaTeX/blob/master/pictures/Colored_examples.jpg)
-
-### Green
+The default theme is blue. Four other themes ship with the classes — pass one as
+a **class option**:
 
 ``` latex
-\usepackage{xcolor}   
-\definecolor{leftcolorband}{HTML}{d0f0c0}   
-\definecolor{boxcolor}{HTML}{59762f}   
-\definecolor{maincolor}{HTML}{556b2f}   
-\definecolor{secondcolor}{HTML}{85b145}   
-\definecolor{thirdcolor}{HTML}{6b8e23}   
+\documentclass[a4paper, green]{arthur-cv}
+\documentclass[a4paper, red]{arthur-cover-letter}
 ```
 
-### Red
+Available: `blue` (default), `green`, `red`, `grey` (or `gray`), `yellow`. The
+same option names work on both classes, so a CV and its cover letter match.
+
+![Colored_Examples](pictures/Colored_examples.jpg)
+
+### Custom colors
+
+For a colour that isn't one of the five themes, redefine the colours in your own
+preamble. This still works and takes precedence over the class option:
 
 ``` latex
-\usepackage{xcolor}   
-\definecolor{leftcolorband}{HTML}{e0e0e0}   
-\definecolor{boxcolor}{HTML}{851919}   
-\definecolor{maincolor}{HTML}{420c0c}   
-\definecolor{secondcolor}{HTML}{861919}   
-\definecolor{thirdcolor}{HTML}{591111}   
+\usepackage{xcolor}
+\definecolor{leftcolorband}{HTML}{d0f0c0}   % grey band behind the left bar
+\definecolor{boxcolor}{HTML}{59762f}        % frame of the left-bar section boxes
+\definecolor{maincolor}{HTML}{556b2f}       % name, first letters of a section
+\definecolor{secondcolor}{HTML}{85b145}     % job title, rest of a section title
+\definecolor{thirdcolor}{HTML}{6b8e23}      % item titles in the body
 ```
 
-### Grey
-
-``` latex
-\usepackage{xcolor}   
-\definecolor{leftcolorband}{HTML}{e0e0e0}   
-\definecolor{boxcolor}{HTML}{606060}   
-\definecolor{maincolor}{HTML}{484848}   
-\definecolor{secondcolor}{HTML}{909090}   
-\definecolor{thirdcolor}{HTML}{606060}   
-```
-
-### Yellow
-
-``` latex
-\usepackage{xcolor}   
-\definecolor{leftcolorband}{HTML}{fef2bf}   
-\definecolor{boxcolor}{HTML}{bfa100}    
-\definecolor{maincolor}{HTML}{5f5000}   
-\definecolor{secondcolor}{HTML}{e1b400}    
-\definecolor{thirdcolor}{HTML}{7f6b00}    
-```
+The cover letter uses `boxcolor`, `maincolor`, `secondcolor` and `colhyperlink`
+(it has no grey band).
 
 ___
 

--- a/arthur-cover-letter.cls
+++ b/arthur-cover-letter.cls
@@ -4,7 +4,27 @@
 % @Last modified by: ArthurBernard
 % @Last modified time: 2020-01-29 19:08:37
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{arthur-cover-letter}[2026/08/27 v1.0.0 Custom cover letter with header class]
+\ProvidesClass{arthur-cover-letter}[2026/08/27 v1.1.0 Custom cover letter with header class]
+
+%%=================%%
+%%  Class options  %%
+%%=================%%
+
+% Colour themes as class options: \documentclass[green]{arthur-cover-letter}.
+% Redefining the colours by hand in the preamble still works and still wins --
+% \definecolor is last-one-wins and the user's preamble is read after the class.
+% That backward-compatible route stays documented in README.md.
+\newcommand{\cv@theme}{blue}
+\DeclareOption{blue}{\renewcommand{\cv@theme}{blue}}
+\DeclareOption{green}{\renewcommand{\cv@theme}{green}}
+\DeclareOption{red}{\renewcommand{\cv@theme}{red}}
+\DeclareOption{grey}{\renewcommand{\cv@theme}{grey}}
+\DeclareOption{gray}{\renewcommand{\cv@theme}{grey}}
+\DeclareOption{yellow}{\renewcommand{\cv@theme}{yellow}}
+% Anything else (a4paper, 11pt, ...) is article's business.
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
+\ProcessOptions\relax
+
 \LoadClass{article}
 
 % TODO : Add option several pages
@@ -29,15 +49,29 @@
 %%  Set colors  %%
 %%==============%%
 
-\definecolor{yt}{HTML}{c71610}
-\definecolor{test}{HTML}{0077be}
-\definecolor{linkedin}{HTML}{0085AE}
+% Icon accents. Deliberately outside the themes: the envelope reads as "mail"
+% and the globe as "web" because of these colours, so they stay fixed.
+\definecolor{yt}{HTML}{c71610}        % mail icon
+\definecolor{test}{HTML}{0077be}      % website icon
+\definecolor{linkedin}{HTML}{0085AE}  % LinkedIn brand
 
-\definecolor{boxcolor}{HTML}{0E5484}
+% The letter has no grey band and no third colour, so it uses four of the five
+% theme slots. Same option names as arthur-cv, so a CV and its letter match.
+% #1 box frame, #2 main, #3 second, #4 hyperlink
+\newcommand{\cv@definetheme}[4]{%
+  \definecolor{boxcolor}{HTML}{#1}%
+  \definecolor{maincolor}{HTML}{#2}%
+  \definecolor{secondcolor}{HTML}{#3}%
+  \definecolor{colhyperlink}{HTML}{#4}%
+}
 
-\definecolor{maincolor}{HTML}{1a4c70}
-\definecolor{secondcolor}{HTML}{4d4d4d}
-\definecolor{colhyperlink}{HTML}{0E5484}
+\newcommand{\cv@theme@blue}  {\cv@definetheme{0E5484}{1a4c70}{4d4d4d}{0E5484}}
+\newcommand{\cv@theme@green} {\cv@definetheme{59762f}{556b2f}{85b145}{6b8e23}}
+\newcommand{\cv@theme@red}   {\cv@definetheme{851919}{420c0c}{861919}{591111}}
+\newcommand{\cv@theme@grey}  {\cv@definetheme{606060}{484848}{909090}{606060}}
+\newcommand{\cv@theme@yellow}{\cv@definetheme{bfa100}{5f5000}{e1b400}{7f6b00}}
+
+\csname cv@theme@\cv@theme\endcsname
 
 %%===============%%
 %%  Information  %%

--- a/arthur-cv.cls
+++ b/arthur-cv.cls
@@ -4,7 +4,27 @@
 % @Last modified by: ArthurBernard
 % @Last modified time: 2023-12-08 10:30:26
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{arthur-cv}[2026/08/27 v1.0.0 Custom CV class]
+\ProvidesClass{arthur-cv}[2026/08/27 v1.1.0 Custom CV class]
+
+%%=================%%
+%%  Class options  %%
+%%=================%%
+
+% Colour themes as class options: \documentclass[green]{arthur-cv}.
+% Redefining the colours by hand in the preamble still works and still wins --
+% \definecolor is last-one-wins and the user's preamble is read after the class.
+% That backward-compatible route stays documented in README.md.
+\newcommand{\cv@theme}{blue}
+\DeclareOption{blue}{\renewcommand{\cv@theme}{blue}}
+\DeclareOption{green}{\renewcommand{\cv@theme}{green}}
+\DeclareOption{red}{\renewcommand{\cv@theme}{red}}
+\DeclareOption{grey}{\renewcommand{\cv@theme}{grey}}
+\DeclareOption{gray}{\renewcommand{\cv@theme}{grey}}
+\DeclareOption{yellow}{\renewcommand{\cv@theme}{yellow}}
+% Anything else (a4paper, 11pt, ...) is article's business.
+\DeclareOption*{\PassOptionsToClass{\CurrentOption}{article}}
+\ProcessOptions\relax
+
 \LoadClass{article}
 
 %%=================%%
@@ -33,16 +53,28 @@
 %%  Set colors  %%
 %%==============%%
 
-\definecolor{yt}{HTML}{c71610}
-\definecolor{test}{HTML}{0077be}
-\definecolor{linkedin}{HTML}{0085AE}
+% Icon accents. Deliberately outside the themes: the envelope reads as "mail"
+% and the globe as "web" because of these colours, so they stay fixed.
+\definecolor{yt}{HTML}{c71610}        % mail icon
+\definecolor{test}{HTML}{0077be}      % website icon
+\definecolor{linkedin}{HTML}{0085AE}  % LinkedIn brand
 
-\definecolor{leftcolorband}{HTML}{E7E7E7}
-\definecolor{boxcolor}{HTML}{0E5484}
+% #1 left band, #2 box frame, #3 main, #4 second, #5 third
+\newcommand{\cv@definetheme}[5]{%
+  \definecolor{leftcolorband}{HTML}{#1}%
+  \definecolor{boxcolor}{HTML}{#2}%
+  \definecolor{maincolor}{HTML}{#3}%
+  \definecolor{secondcolor}{HTML}{#4}%
+  \definecolor{thirdcolor}{HTML}{#5}%
+}
 
-\definecolor{maincolor}{HTML}{1a4c70}
-\definecolor{secondcolor}{HTML}{4d4d4d}
-\definecolor{thirdcolor}{HTML}{0E5484}
+\newcommand{\cv@theme@blue}  {\cv@definetheme{E7E7E7}{0E5484}{1a4c70}{4d4d4d}{0E5484}}
+\newcommand{\cv@theme@green} {\cv@definetheme{d0f0c0}{59762f}{556b2f}{85b145}{6b8e23}}
+\newcommand{\cv@theme@red}   {\cv@definetheme{e0e0e0}{851919}{420c0c}{861919}{591111}}
+\newcommand{\cv@theme@grey}  {\cv@definetheme{e0e0e0}{606060}{484848}{909090}{606060}}
+\newcommand{\cv@theme@yellow}{\cv@definetheme{fef2bf}{bfa100}{5f5000}{e1b400}{7f6b00}}
+
+\csname cv@theme@\cv@theme\endcsname
 
 
 %%===============%%

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -90,7 +90,4 @@ roadmap.
   pass one. That works only by accident: `\newcommand` builds `\long` macros, so
   the `\par` from the following blank line silently becomes the second argument.
   Pass `{}` explicitly.
-- **No class options** are declared (`\DeclareOption`/`\ProcessOptions` are
-  absent), so colour themes can only be applied by re-`\definecolor`ing in the
-  user preamble.
 - **`fontawesome`** is FontAwesome 4.7, frozen upstream; `fontawesome5` exists.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -24,10 +24,10 @@ dated ADR log.
   both languages, both conventions, and the multi-page path. Page-count checks
   catch the layout regressions that a clean compile would miss.
 
-- **Colour theming by re-`\definecolor`, historically.** Five named colours are
-  defined in the class and the README tells users to redefine them in their
-  preamble; the later `\definecolor` wins. It works but is unusual — class
-  options are the idiomatic mechanism and are on the roadmap.
+- **Colour theming by class option, with the preamble override kept.** Themes
+  are `\DeclareOption`s that pick a palette; because `\definecolor` is
+  last-one-wins and the user preamble is read after the class, redefining the
+  colours by hand still overrides the theme. Both routes are documented.
 
 ## Decision journal
 
@@ -108,3 +108,24 @@ to compile against the previous class and succeeds against this one.
 `\makeprofile` tolerate an unset one-argument macro. There is no clean way to
 test that from `\ifthenelse`, and the fragility would remain for anyone reading
 a field directly.
+
+### 2026-08-27 — Colour themes become class options
+
+**Context.** The four extra themes existed only as five `\definecolor` lines to
+copy out of the README. The classes declared no options at all — no
+`\DeclareOption`, no `\ProcessOptions` — so there was no mechanism to offer.
+
+**Decision.** Declare `blue`/`green`/`red`/`grey`/`gray`/`yellow` as class
+options selecting a palette, with `\DeclareOption*` forwarding everything else
+to `article` and `\ProcessOptions\relax` before `\LoadClass`. Same option names
+on both classes so a CV and its letter match.
+
+**Backward compatibility is the whole constraint** (frozen public API). Verified
+three ways: every existing example renders byte-identically under the default
+theme; `[11pt]` still reaches `article`; and a preamble that redefines the five
+colours to the README's yellow values renders **byte-identically to
+`[yellow]`** — so the palettes are faithful and the old route still wins.
+
+*Note:* the letter has no grey band and no `thirdcolor`, so its palettes carry
+four slots against the CV's five. Same option names, different arity — kept
+deliberately rather than inventing unused colours for the letter.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -13,8 +13,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
 - **Six examples** covering both classes, both languages, both conventions, the
   multi-page path and the omitted-field edge. Four are the author's real
   documents; `example_cv` and `minimal_cv` are skeletons.
-- **Colour theming** by redefining five colours in the user preamble; four ready
-  themes (green/red/grey/yellow) documented in the root `README.md`.
+- **Colour theming** by class option (`[green]`, `[red]`, `[grey]`, `[yellow]`,
+  default `blue`) on both classes; redefining the colours in the preamble still
+  works and still wins, for palettes outside the five themes.
 - **Dev loop adopted (2026-08-27)** — `develop` branch, `.claude/` config,
   canonical hook copies, this `doc/dev/` pack, `CHANGELOG.md`.
 - **Class hygiene (2026-08-27)** — header fields initialised (omitting one is

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -28,10 +28,6 @@ here: git log + `CHANGELOG.md` are authoritative for *what* shipped,
 
 ## 3. API & ergonomics
 
-- [ ] Declare class options for the colour themes so
-      `\documentclass[green]{arthur-cv}` replaces copying five `\definecolor`
-      lines into the preamble. Needs `\DeclareOption`/`\ProcessOptions`, which
-      the class currently lacks entirely.
 - [ ] Factor `\makeprofile` into a shared `arthur-cv-header.sty` required by both
       classes — the two copies have already drifted (`0.43` vs `0.45\textwidth`).
 - [ ] Provide `cvleft`/`cvright` environments so the side-bar/body widths stop


### PR DESCRIPTION
The four extra themes existed only as five `\definecolor` lines to copy out of
the README. The classes declared **no options at all** — no `\DeclareOption`, no
`\ProcessOptions` — so there was no mechanism to offer one.

```latex
\documentclass[a4paper, green]{arthur-cv}
```

`blue` (default), `green`, `red`, `grey`/`gray`, `yellow`. The same names work on
`arthur-cover-letter`, so a CV and its letter match. `\DeclareOption*` forwards
anything else to `article`.

## Backward compatibility was the whole constraint

Verified three ways:

1. Every existing example renders **byte-identically** under the default theme.
2. `[11pt]` still reaches `article`.
3. A preamble redefining the five colours to the README's yellow values renders
   **byte-identically to `[yellow]`** — so the palettes are faithful *and* the
   documented override route still takes precedence.

## Note

The letter has no grey band and no `thirdcolor`, so its palettes carry four
slots against the CV's five. Same option names, different arity — kept
deliberately rather than inventing unused colours for the letter.

---
📚 3/6. Base: `fix/class-robustness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)