### PR TITLE
refactor: share the header between classes, add layout environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The classes carried no version marker before this file existed; history prior to
 
 ### Added
 
+- **`cvbody` / `cvleft` / `cvright` environments** own the side-bar and body
+  column widths, which previously had to be written out in every document and
+  kept in step with numbers hard-coded in the class. The explicit
+  `textblock` + `minipage` form still works unchanged.
 - **Colour themes as class options** — `\documentclass[green]{arthur-cv}`.
   `blue` (default), `green`, `red`, `grey`/`gray`, `yellow`; the same names work
   on `arthur-cover-letter`. Redefining the colours in your own preamble still
@@ -27,6 +31,9 @@ The classes carried no version marker before this file existed; history prior to
   copies).
 
 ### Changed
+
+- `\makeprofile` is now defined once in a new `arthur-cv-header.sty` required by
+  both classes, instead of being copy-pasted into each. Rendering is unchanged.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,10 @@ a second pass is tikz `remember picture`).
 2. **Examples are the contract.** `examples/*.tex` must compile with an
    unmodified class. If a change needs an example edit, the change is
    API-breaking — reconsider it.
-3. **The two classes must render an identical header.** `\makeprofile` is
-   currently copy-pasted into both `.cls` files and the copies have already
-   drifted (`0.43` vs `0.45\textwidth`). Until that is factored out
-   (`07-roadmap.md`), any header edit must be applied to **both** files.
+3. **Both classes share one header.** `\makeprofile` is composed from
+   `arthur-cv-header.sty`, required by both. Never re-fork it — the two copies
+   had already drifted before it was factored out. The class-specific bits are
+   parameters (`\cv@headerblock{width}{namewidth}`, `\cv@headerextra`).
 4. **Compile with LuaLaTeX** (or XeLaTeX). `fontspec` makes pdfLaTeX
    impossible; don't add anything that assumes pdfLaTeX.
 5. **No page-count surprises.** The layout is absolutely positioned

--- a/README.md
+++ b/README.md
@@ -71,8 +71,28 @@ This template is divided in three parts:
   - The **left bar** to display some skills or other;   
   - The **body** of your CV to display your experiences, educations, etc.   
 
-The left bar and body must be each one in a `minipage` environment with respectively `0.37\textwidth` and `0.61\textwidth` parameters.   
-You can look one of the following examples: `example_cv.tex`, `Arthur_Bernard_CV_Fr.tex` or `Arthur_Bernard_CV_En.tex`
+Wrap the left bar and the body in the `cvbody` / `cvleft` / `cvright`
+environments — they own the column widths, so there is nothing to keep in sync:
+
+``` latex
+\begin{cvbody}
+  \begin{cvleft}
+    % \sectionleft, \subsectionleft ...
+  \end{cvleft}
+  \begin{cvright}
+    % \section, rightenv ...
+  \end{cvright}
+\end{cvbody}
+```
+
+`cvbody` takes an optional vertical offset in cm (default `3.5`); use
+`\begin{cvbody}[0.0]` for a page opened by `\newcvpage`.
+
+See `example_cv.tex` for this form. The older explicit form — opening a
+`textblock` and two `minipage`s by hand with `0.37\textwidth` and
+`0.61\textwidth` — still works unchanged, and is what
+`Arthur_Bernard_CV_En.tex`, `Arthur_Bernard_CV_Fr.tex` and `Two_Pages_CV.tex`
+use.
 
 ### Header
 
@@ -121,6 +141,15 @@ Set items in body:
   \subsectionright{Date}[Level degree]{Title}[University][Location]{Description}   
   \subsectionright{Date}{Title job}[Firm][Location]{Description}   
 \end{rightenv}   
+```
+
+### Layout
+
+``` latex
+\begin{cvbody}[vertical offset in cm, default 3.5]
+  \begin{cvleft} ... \end{cvleft}
+  \begin{cvright} ... \end{cvright}
+\end{cvbody}
 ```
 
 ### Several pages

--- a/arthur-cover-letter.cls
+++ b/arthur-cover-letter.cls
@@ -44,6 +44,9 @@
 \RequirePackage{tikz}                 % Graphic
 \RequirePackage{xcolor}               % Colors
 \RequirePackage{ifthen}               % Conditions
+% Header shared with arthur-cv; must come after textpos and tikz, which it uses
+% at load time.
+\RequirePackage{arthur-cv-header}
 
 %%==============%%
 %%  Set colors  %%
@@ -73,140 +76,18 @@
 
 \csname cv@theme@\cv@theme\endcsname
 
-%%===============%%
-%%  Information  %%
-%%===============%%
-
-% Declare a header field: \cv@declarefield{cvmail}{mail} creates the public
-% setter \cvmail{...}, which stores its argument in \cv@mail. The storage macro
-% is initialised *empty*, so simply omitting a field is exactly as safe as
-% calling it with {}. Before this, an omitted field left a macro still expecting
-% an argument, and the \equal test in \makeprofile then failed with an
-% unreadable error -- the most likely first-run failure for a new user.
-\newcommand{\cv@declarefield}[2]{%
-  \expandafter\newcommand\csname cv@#2\endcsname{}%
-  \expandafter\newcommand\csname #1\endcsname[1]{%
-    \expandafter\renewcommand\csname cv@#2\endcsname{##1}%
-  }%
-}
-
-\cv@declarefield{cvname}{name}
-\cv@declarefield{cvjobtitle}{jobtitle}
-\cv@declarefield{cvlinkedin}{linkedin}
-\cv@declarefield{cvgithub}{github}
-\cv@declarefield{cvmail}{mail}
-\cv@declarefield{cvnumberphone}{numberphone}
-\cv@declarefield{cvsite}{site}
-\cv@declarefield{profilepic}{profilepic}
-
 %%==========%%
 %%  Header  %%
 %%==========%%
 
-% Set unit
-\setlength{\TPHorizModule}{1cm}
-\setlength{\TPVertModule}{1cm}
-
-% Set image size
-\newcommand{\imsize}{\linewidth}
-\newlength\imagewidth
-\newlength\imagescale
-\renewcommand{\imsize}{0.618\linewidth}
-\pgfmathsetlength{\imagewidth}{3cm}%
-\pgfmathsetlength{\imagescale}{\imagewidth/600}%
-
-% Set header
+% Fields and header pieces come from arthur-cv-header.sty. The letter shows no
+% address or age under the job title, so \cv@headerextra stays empty, and it has
+% no grey band -- hence no tikz node here.
 \newcommand{\makeprofile}{
-  
-  %----------------------%
-  % Personal information %
-  %----------------------%
 
-  \begin{textblock}{20.25}(0.25, 0.25)
+  \cv@headerblock{20.25}{0.45}
+  \cv@photoblock
 
-    \begin{minipage}[t]{0.38\textwidth}
-
-      % Set information
-      \vspace{3mm}
-      \renewcommand{\arraystretch}{1.4}
-      \begin{tabular}{p{1.1cm} @{\hskip 0.3cm}p{6.2cm}}
-        % Set phone
-        \ifthenelse{\equal{\cv@numberphone}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{4mm} \textnormal{\LARGE \faMobile} 
-            \end{array}
-          $} & \large\cv@numberphone\\
-        }
-        % Set site
-        \ifthenelse{\equal{\cv@site}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{2.8mm} \textnormal{\textcolor{test}{\Large \faGlobe}}
-            \end{array}
-          $} & \href{http://\cv@site}{\large\cv@site} \\
-        }
-        % Set eMail
-        \ifthenelse{\equal{\cv@mail}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{2.5mm} \textnormal{\Large \textcolor{yt}{\faEnvelopeO}}
-            \end{array}
-          $} & \href{mailto:\cv@mail}{\large\cv@mail} \\
-        }
-        % Set LinkendIn
-        \ifthenelse{\equal{\cv@linkedin}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{3mm} \textnormal{\Large \textcolor{linkedin}{\faLinkedin}}
-            \end{array}
-          $} & \href{https://www.linkedin.com\cv@linkedin}{\large\cv@linkedin} \\
-        }
-        % Set GitHub
-        \ifthenelse{\equal{\cv@github}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{3mm} \textnormal{\Large \faGithub}
-            \end{array}
-          $} & \href{https://www.github.com/\cv@github}{\large\cv@github} \\
-        }
-      
-      \end{tabular}
-
-    \end{minipage}
-    \begin{minipage}[t]{0.45\textwidth}
-
-      %----------------%
-      % Name and title %
-      %----------------%
-
-      % Set name and title letter
-      \vspace{3mm}
-      {\hspace{0mm}\Huge\color{maincolor}\cv@name}
-      
-      \vspace{5mm}
-
-      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cv@jobtitle}}
-
-    \end{minipage}
-
-  \end{textblock}
-
-  %---------%
-  % Picture %
-  %---------%
-
-  \begin{textblock}{3.5}(17.25, 0.25)
-
-    % Display picture and box if provided else nothing
-    \ifthenelse{\equal{\cv@profilepic}{}}{}{
-      \begin{tikzpicture}[remember picture,overlay]
-        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\cv@profilepic}};
-        \draw[line width=0.5mm, boxcolor] (0.20cm, 0.05cm) -- + (3.15cm, 0) -- + (3.15cm, -3.15cm) -- + (0,-3.15cm) -- cycle;
-      \end{tikzpicture}
-    }
-
-  \end{textblock}
 }
 
 %%=================================%%

--- a/arthur-cv-header.sty
+++ b/arthur-cv-header.sty
@@ -1,0 +1,217 @@
+% Shared header for arthur-cv and arthur-cover-letter.
+%
+% \makeprofile used to be copy-pasted into both classes, and the copies had
+% already drifted (the name column was 0.43\textwidth in one and 0.45 in the
+% other). The contact table, the photo block and the field declarations are
+% identical between the two, so they live here; the four things that genuinely
+% differ are parameters:
+%
+%   grey band            drawn by the class, not here (the letter has none)
+%   header block width   20.5 for the CV, 20.25 for the letter
+%   name column width    0.43 for the CV, 0.45 for the letter
+%   \cv@headerextra      address + age for the CV, empty for the letter
+%
+% This package is required by both classes; it is not meant to be loaded
+% directly by a document.
+
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{arthur-cv-header}[2026/08/27 v1.0.0 Shared header for arthur-cv]
+
+%%===============%%
+%%  Information  %%
+%%===============%%
+
+% Declare a header field: \cv@declarefield{cvmail}{mail} creates the public
+% setter \cvmail{...}, which stores its argument in \cv@mail. The storage macro
+% is initialised *empty*, so simply omitting a field is exactly as safe as
+% calling it with {}. Before this, an omitted field left a macro still expecting
+% an argument, and the \equal test in \makeprofile then failed with an
+% unreadable error -- the most likely first-run failure for a new user.
+\newcommand{\cv@declarefield}[2]{%
+  \expandafter\newcommand\csname cv@#2\endcsname{}%
+  \expandafter\newcommand\csname #1\endcsname[1]{%
+    \expandafter\renewcommand\csname cv@#2\endcsname{##1}%
+  }%
+}
+
+% Fields common to both classes. arthur-cv declares \cvaddress and \cvyearsold
+% on top of these; the cover letter has no use for them.
+\cv@declarefield{cvname}{name}
+\cv@declarefield{cvjobtitle}{jobtitle}
+\cv@declarefield{cvlinkedin}{linkedin}
+\cv@declarefield{cvgithub}{github}
+\cv@declarefield{cvmail}{mail}
+\cv@declarefield{cvnumberphone}{numberphone}
+\cv@declarefield{cvsite}{site}
+\cv@declarefield{profilepic}{profilepic}
+
+% Extra lines under the job title. Set by the class, never by the document.
+\newcommand{\cv@headerextra}{}
+
+%%==========%%
+%%  Header  %%
+%%==========%%
+
+% Set unit
+\setlength{\TPHorizModule}{1cm}
+\setlength{\TPVertModule}{1cm}
+
+% Set image size
+\newcommand{\imsize}{\linewidth}
+\newlength\imagewidth
+\newlength\imagescale
+\renewcommand{\imsize}{0.618\linewidth}
+\pgfmathsetlength{\imagewidth}{3cm}%
+\pgfmathsetlength{\imagescale}{\imagewidth/600}%
+
+% NOTE on the trailing `\end{minipage}` of the two column macros: it is followed
+% by a newline, not by `%`, on purpose. The original inline code had *two* space
+% tokens between the two minipages, and the header row is set flush, so removing
+% one shifts the name column 2.69 pt to the left. Keep the newlines.
+
+% The contact column: one row per field that is set, none for the others.
+\newcommand{\cv@contactcolumn}{%
+    \begin{minipage}[t]{0.38\textwidth}
+
+      % Set information
+      \vspace{3mm}
+      \renewcommand{\arraystretch}{1.4}
+      \begin{tabular}{p{1.1cm} @{\hskip 0.3cm}p{6.2cm}}
+        % Set phone
+        \ifthenelse{\equal{\cv@numberphone}{}}{}{
+          {$
+            \begin{array}{l}
+              \hspace{4mm} \textnormal{\LARGE \faMobile}
+            \end{array}
+          $} & \large\cv@numberphone\\
+        }
+        % Set site
+        \ifthenelse{\equal{\cv@site}{}}{}{
+          {$
+            \begin{array}{l}
+              \hspace{2.8mm} \textnormal{\textcolor{test}{\Large \faGlobe}}
+            \end{array}
+          $} & \href{http://\cv@site}{\large\cv@site} \\
+        }
+        % Set eMail
+        \ifthenelse{\equal{\cv@mail}{}}{}{
+          {$
+            \begin{array}{l}
+              \hspace{2.5mm} \textnormal{\Large \textcolor{yt}{\faEnvelopeO}}
+            \end{array}
+          $} & \href{mailto:\cv@mail}{\large\cv@mail} \\
+        }
+        % Set LinkendIn
+        \ifthenelse{\equal{\cv@linkedin}{}}{}{
+          {$
+            \begin{array}{l}
+              \hspace{3mm} \textnormal{\Large \textcolor{linkedin}{\faLinkedin}}
+            \end{array}
+          $} & \href{https://www.linkedin.com\cv@linkedin}{\large\cv@linkedin} \\
+        }
+        % Set GitHub
+        \ifthenelse{\equal{\cv@github}{}}{}{
+          {$
+            \begin{array}{l}
+              \hspace{3mm} \textnormal{\Large \faGithub}
+            \end{array}
+          $} & \href{https://www.github.com/\cv@github}{\large\cv@github} \\
+        }
+
+      \end{tabular}
+
+    \end{minipage}
+}
+
+% The name column. #1 is the minipage width as a fraction of \textwidth.
+\newcommand{\cv@namecolumn}[1]{%
+    \begin{minipage}[t]{#1\textwidth}
+
+      %----------------%
+      % Name and title %
+      %----------------%
+
+      % Set name and title
+      \vspace{3mm}
+      {\hspace{0mm}\Huge\color{maincolor}\cv@name}
+
+      \vspace{5mm}
+
+      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cv@jobtitle}}
+
+      \cv@headerextra
+    \end{minipage}
+}
+
+% The header row. #1 is the enclosing textblock width, #2 the name column width.
+\newcommand{\cv@headerblock}[2]{%
+  %-----------------------%
+  % Personal informations %
+  %-----------------------%
+
+  \begin{textblock}{#1}(0.25, 0.25)
+
+    \cv@contactcolumn
+    \cv@namecolumn{#2}
+
+  \end{textblock}%
+}
+
+% The photo, framed, top right. Nothing at all when \profilepic is unset.
+\newcommand{\cv@photoblock}{%
+  %---------%
+  % Picture %
+  %---------%
+
+  \begin{textblock}{3.5}(17.25, 0.25)
+
+    % Display picture and box if provided else nothing
+    \ifthenelse{\equal{\cv@profilepic}{}}{}{
+      \begin{tikzpicture}[remember picture,overlay]
+        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\cv@profilepic}};
+        \draw[line width=0.5mm, boxcolor] (0.20cm, 0.05cm) -- + (3.15cm, 0) -- + (3.15cm, -3.15cm) -- + (0,-3.15cm) -- cycle;
+      \end{tikzpicture}
+    }
+
+  \end{textblock}%
+}
+
+%%=================%%
+%%  Body layout    %%
+%%=================%%
+
+% The side bar and the body used to be minipages that the *document* had to open
+% itself, with widths (0.37 / 0.61) that had to agree with numbers hard-coded in
+% arthur-cv.cls. Getting them out of step broke the layout silently, which is why
+% the README told people not to touch them. These environments own the numbers:
+%
+%   \begin{cvbody}                 % optional arg: vertical offset in cm (3.5)
+%     \begin{cvleft}  ... \end{cvleft}
+%     \begin{cvright} ... \end{cvright}
+%   \end{cvbody}
+%
+% The explicit textblock/minipage form still works exactly as before -- the
+% public API is frozen and existing CVs must keep compiling.
+\newcommand{\cvleftwidth}{0.37}
+\newcommand{\cvrightwidth}{0.61}
+
+\newenvironment{cvbody}[1][3.5]{%
+  \begin{textblock}{20.5}(0.25, #1)%
+}{%
+  \end{textblock}%
+}
+
+% \hfill lives at the end of cvleft, matching the original
+% `\end{minipage}\hfill\begin{minipage}`; \ignorespacesafterend drops the source
+% newline that would otherwise add a space the inline form never had.
+\newenvironment{cvleft}{%
+  \begin{minipage}[t]{\cvleftwidth\textwidth}%
+}{%
+  \end{minipage}\hfill\ignorespacesafterend
+}
+
+\newenvironment{cvright}{%
+  \begin{minipage}[t]{\cvrightwidth\textwidth}%
+}{%
+  \end{minipage}%
+}

--- a/arthur-cv.cls
+++ b/arthur-cv.cls
@@ -48,6 +48,9 @@
 \RequirePackage{tcolorbox}            % Colored box
 \RequirePackage{enumitem}             % Customize item
 \RequirePackage{ifthen}               % Conditions
+% Header shared with arthur-cover-letter; must come after textpos and tikz,
+% which it uses at load time.
+\RequirePackage{arthur-cv-header}
 
 %%==============%%
 %%  Set colors  %%
@@ -81,149 +84,33 @@
 %%  Information  %%
 %%===============%%
 
-% Declare a header field: \cv@declarefield{cvmail}{mail} creates the public
-% setter \cvmail{...}, which stores its argument in \cv@mail. The storage macro
-% is initialised *empty*, so simply omitting a field is exactly as safe as
-% calling it with {}. Before this, an omitted field left a macro still expecting
-% an argument, and the \equal test in \makeprofile then failed with an
-% unreadable error -- the most likely first-run failure for a new user.
-\newcommand{\cv@declarefield}[2]{%
-  \expandafter\newcommand\csname cv@#2\endcsname{}%
-  \expandafter\newcommand\csname #1\endcsname[1]{%
-    \expandafter\renewcommand\csname cv@#2\endcsname{##1}%
-  }%
-}
-
-\cv@declarefield{cvname}{name}
-\cv@declarefield{cvjobtitle}{jobtitle}
-\cv@declarefield{cvlinkedin}{linkedin}
-\cv@declarefield{cvgithub}{github}
-\cv@declarefield{cvmail}{mail}
-\cv@declarefield{cvnumberphone}{numberphone}
+% The fields common to both classes are declared in arthur-cv-header.sty.
+% These two are CV-only: a cover letter shows neither an address nor an age.
 \cv@declarefield{cvaddress}{address}
-\cv@declarefield{cvsite}{site}
 \cv@declarefield{cvyearsold}{yearsold}
-\cv@declarefield{profilepic}{profilepic}
 
-%%==========%%
-%%  Header  %%
-%%==========%%
-
-% Set unit
-\setlength{\TPHorizModule}{1cm}
-\setlength{\TPVertModule}{1cm}
-
-% Set image size
-\newcommand{\imsize}{\linewidth}
-\newlength\imagewidth
-\newlength\imagescale
-\renewcommand{\imsize}{0.618\linewidth}
-\pgfmathsetlength{\imagewidth}{3cm}%
-\pgfmathsetlength{\imagescale}{\imagewidth/600}%
-
-% Set header
-\newcommand{\makeprofile}{
-  
-  % Set left color band
-  \begin{tikzpicture}[remember picture,overlay]
-    \node [rectangle, anchor=north west, fill=leftcolorband, minimum width=8cm, minimum height=27cm] at (0cm, -3.2cm) {};{};
-  \end{tikzpicture}
-
-  %-----------------------%
-  % Personal informations %
-  %-----------------------%
-
-  \begin{textblock}{20.5}(0.25, 0.25)
-
-    \begin{minipage}[t]{0.38\textwidth}
-
-      % Set information
-      \vspace{3mm}
-      \renewcommand{\arraystretch}{1.4}
-      \begin{tabular}{p{1.1cm} @{\hskip 0.3cm}p{6.2cm}}
-        % Set phone
-        \ifthenelse{\equal{\cv@numberphone}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{4mm} \textnormal{\LARGE \faMobile} 
-            \end{array}
-          $} & \large\cv@numberphone\\
-        }
-        % Set site
-        \ifthenelse{\equal{\cv@site}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{2.8mm} \textnormal{\textcolor{test}{\Large \faGlobe}}
-            \end{array}
-          $} & \href{http://\cv@site}{\large\cv@site} \\
-        }
-        % Set eMail
-        \ifthenelse{\equal{\cv@mail}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{2.5mm} \textnormal{\Large \textcolor{yt}{\faEnvelopeO}}
-            \end{array}
-          $} & \href{mailto:\cv@mail}{\large\cv@mail} \\
-        }
-        % Set LinkendIn
-        \ifthenelse{\equal{\cv@linkedin}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{3mm} \textnormal{\Large \textcolor{linkedin}{\faLinkedin}}
-            \end{array}
-          $} & \href{https://www.linkedin.com\cv@linkedin}{\large\cv@linkedin} \\
-        }
-        % Set GitHub
-        \ifthenelse{\equal{\cv@github}{}}{}{
-          {$
-            \begin{array}{l}
-              \hspace{3mm} \textnormal{\Large \faGithub}
-            \end{array}
-          $} & \href{https://www.github.com/\cv@github}{\large\cv@github} \\
-        }
-      
-      \end{tabular}
-
-    \end{minipage}
-    \begin{minipage}[t]{0.43\textwidth}
-
-      %----------------%
-      % Name and title %
-      %----------------%
-
-      % Set name and title CV
-      \vspace{3mm}
-      {\hspace{0mm}\Huge\color{maincolor}\cv@name}
-      
-      \vspace{5mm}
-
-      {\hspace{0mm}\Large\color{secondcolor}\textbf{\cv@jobtitle}}
-
+% Shown under the job title, in the header's name column.
+\renewcommand{\cv@headerextra}{%
       \vspace{3mm}
 
       {\hspace{0mm}\cv@address}
 
       {\hspace{0mm}\cv@yearsold}
+}
 
-    \end{minipage}
+%%==========%%
+%%  Header  %%
+%%==========%%
 
-  \end{textblock}
+\newcommand{\makeprofile}{
 
-  %---------%
-  % Picture %
-  %---------%
+  % Set left color band
+  \begin{tikzpicture}[remember picture,overlay]
+    \node [rectangle, anchor=north west, fill=leftcolorband, minimum width=8cm, minimum height=27cm] at (0cm, -3.2cm) {};{};
+  \end{tikzpicture}
 
-  \begin{textblock}{3.5}(17.25, 0.25)
-
-    % Display picture and box if provided else nothing
-    \ifthenelse{\equal{\cv@profilepic}{}}{}{
-      \begin{tikzpicture}[remember picture,overlay]
-        \node[rectangle, anchor=north west] at (0.15cm, 0.1cm) {\includegraphics[width=\imagewidth]{\cv@profilepic}};
-        \draw[line width=0.5mm, boxcolor] (0.20cm, 0.05cm) -- + (3.15cm, 0) -- + (3.15cm, -3.15cm) -- + (0,-3.15cm) -- cycle;
-      \end{tikzpicture}
-    }
-
-  \end{textblock}
+  \cv@headerblock{20.5}{0.43}
+  \cv@photoblock
 
 }
 

--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -18,8 +18,9 @@ public API — see the invariants in `CLAUDE.md`.
 ## Repo map
 
 ```
-arthur-cv.cls              # the CV class (~275 lines)
-arthur-cover-letter.cls    # the cover-letter class (~245 lines)
+arthur-cv.cls              # the CV class
+arthur-cover-letter.cls    # the cover-letter class
+arthur-cv-header.sty       # header + layout environments shared by both
 examples/                  # 6 .tex + committed reference .pdf
   example_cv.tex           #   skeleton (John Doe)
   minimal_cv.tex           #   smallest possible CV; omits most header fields
@@ -36,6 +37,9 @@ README.md                  # end-user documentation
 Header (both classes): `\profilepic` `\cvname` `\cvlinkedin` `\cvgithub`
 `\cvmail` `\cvnumberphone` `\cvjobtitle` `\cvsite`, plus `\cvaddress`
 `\cvyearsold` (CV only). Rendered by `\makeprofile`.
+
+CV layout: `cvbody` (optional vertical offset) containing `cvleft` and
+`cvright`; the explicit `textblock` + `minipage` form still works.
 
 CV body: `\sectionleft{title}` and `\subsectionleft{item}{desc}` for the side
 bar; `\section{title}` and, inside a `rightenv` environment,

--- a/doc/dev/02-architecture.md
+++ b/doc/dev/02-architecture.md
@@ -29,8 +29,10 @@ Both classes set zero page margins via `geometry` and place **everything** in
 └──────────────────┴─────────────────────────────┘
 ```
 
-The user's `.tex` opens the `textblock` and the two `minipage`s itself (see any
-example); the class only provides the commands used *inside* them.
+The `cvbody` / `cvleft` / `cvright` environments open the `textblock` and the two
+`minipage`s; the document only supplies the content. Documents written before
+those existed open them by hand, which still works — see
+`Arthur_Bernard_CV_En.tex` for that form and `example_cv.tex` for the new one.
 
 ### Header — `\makeprofile`
 
@@ -43,12 +45,18 @@ its argument in a private macro (`\cv@mail`) that is **initialised empty**.
 `\ifthenelse{\equal{\cv@foo}{}}{}{...}`, so a field that is unset — whether
 passed `{}` or omitted entirely — renders nothing.
 
+`\makeprofile` itself lives in **`arthur-cv-header.sty`**, required by both
+classes; each class composes it from `\cv@headerblock{<tb width>}{<name width>}`
+and `\cv@photoblock`, and fills the `\cv@headerextra` hook (address + age for
+the CV, empty for the letter). The grey band is drawn by `arthur-cv.cls` alone.
+
 Two implementation notes:
 
+- **The two space tokens between the contact column and the name column are
+  load-bearing.** The header row is set flush, so collapsing them to one shifts
+  the name 2.69 pt left. `arthur-cv-header.sty` says so at the call site.
 - The icons are vertically aligned with a `$\begin{array}{l}\hspace{Nmm}…\end{array}$`
   wrapper and a per-icon hand-tuned `\hspace`. It is a hack; a `\makebox` would do.
-- **`\makeprofile` is copy-pasted into both classes** and the copies have already
-  drifted (`0.43\textwidth` in `arthur-cv`, `0.45` in `arthur-cover-letter`).
 
 ### Side bar
 
@@ -65,20 +73,19 @@ sectioning command (no TOC, no bookmarks, no optional argument, no numbering).
 that the README documents by example. It lays out inside `rightenv`, a
 `tabular{p{1.6cm} l}` whose second cell is a `\parbox[t]{10.5cm}`.
 
-## The fragile seam
+## The width seam
 
-Three widths must agree, and they live in two different files:
+Three widths must agree:
 
 | Value | Where | Meaning |
 |---|---|---|
 | `8cm` | `arthur-cv.cls`, tikz band | grey band width |
-| `0.37\textwidth` / `0.61\textwidth` | **the user's `.tex`** | side bar / body minipages |
+| `\cvleftwidth` / `\cvrightwidth` (`0.37` / `0.61`) | `arthur-cv-header.sty` | side bar / body minipages |
 | `10.5cm` | `arthur-cv.cls`, `\subsectionright` | body text wrap width |
 
-Change one without the others and the layout silently breaks. This is why the
-root README says *"don't custom textblock and minipage … if you don't know what
-you are doing"*. Factoring these into class-provided environments is on the
-roadmap.
+These now all live in the package, so a document using `cvbody`/`cvleft`/
+`cvright` cannot desynchronise them. A document using the older explicit
+`minipage` form still hard-codes `0.37`/`0.61` itself and can.
 
 ## Known fragilities (read before touching)
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -129,3 +129,33 @@ colours to the README's yellow values renders **byte-identically to
 *Note:* the letter has no grey band and no `thirdcolor`, so its palettes carry
 four slots against the CV's five. Same option names, different arity — kept
 deliberately rather than inventing unused colours for the letter.
+
+### 2026-08-27 — Shared header package and layout environments
+
+**Context.** `\makeprofile` was copy-pasted into both classes and the copies had
+drifted (name column `0.43\textwidth` in the CV, `0.45` in the letter). Separately,
+the side-bar/body widths lived in the *document*, while widths they had to agree
+with lived in the class — the reason the README warned people off touching them.
+
+**Decision.** `arthur-cv-header.sty`, required by both classes, holds the field
+declarations, the contact column, the name column and the photo block. The four
+genuine differences are parameters: the grey band (drawn by `arthur-cv` only),
+the header-block width, the name-column width, and the `\cv@headerextra` hook.
+The drift is preserved as data rather than "fixed", because changing either
+number would move a real document.
+
+The same package adds `cvbody` / `cvleft` / `cvright`, which own `\cvleftwidth`
+and `\cvrightwidth`. The explicit form still works — the API is frozen — so the
+examples deliberately cover **both**: `example_cv.tex` uses the environments,
+the three real CVs keep the explicit form.
+
+**Verification.** Every example renders byte-identically at 100 dpi before and
+after, including `example_cv.tex` *after* converting it to the new environments.
+That is the whole claim: a pure refactor plus an additive API.
+
+**One trap worth knowing.** The original inline code had **two** space tokens
+between the contact and name minipages. The header row is set flush, so
+collapsing them to one moves the name 2.69 pt left — which is exactly what the
+first attempt did, caught by the pixel comparison and not by the compile. The
+trailing newlines in the two column macros are load-bearing and commented as
+such.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -18,6 +18,9 @@ so an agent doesn't re-investigate settled ground or assume a known stub is a bu
   works and still wins, for palettes outside the five themes.
 - **Dev loop adopted (2026-08-27)** — `develop` branch, `.claude/` config,
   canonical hook copies, this `doc/dev/` pack, `CHANGELOG.md`.
+- **Shared header + layout environments (2026-08-27)** — `\makeprofile` factored
+  into `arthur-cv-header.sty`; `cvbody`/`cvleft`/`cvright` own the column widths.
+  Both verified byte-identical in output.
 - **Class hygiene (2026-08-27)** — header fields initialised (omitting one is
   safe), `etoolbox` required explicitly, identification before `\LoadClass`,
   unused packages dropped, classes versioned `v1.0.0`.
@@ -30,10 +33,9 @@ Ordered by how likely they are to bite someone. Details in
 
 - **`\@sectioncolor` eats tokens** on `\section` titles shorter than three
   tokens or starting with a macro/group.
-- **The left/right widths are split across the class and the user's `.tex`**, so
-  the layout can only be customised by editing numbers in two files.
-- **`\makeprofile` is duplicated** across the two classes and has already
-  drifted.
+- **Documents using the old explicit `minipage` form** still hard-code the
+  `0.37`/`0.61` widths themselves; only `cvbody`/`cvleft`/`cvright` users are
+  protected from desynchronising them.
 - **No page-break support** — overflowing content silently runs off the page.
   This is by design (see `03-decisions.md`), but it is a real usability edge.
 - **`\subsectionleft` needs both braces**; passing one silently feeds it a

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -28,11 +28,6 @@ here: git log + `CHANGELOG.md` are authoritative for *what* shipped,
 
 ## 3. API & ergonomics
 
-- [ ] Factor `\makeprofile` into a shared `arthur-cv-header.sty` required by both
-      classes — the two copies have already drifted (`0.43` vs `0.45\textwidth`).
-- [ ] Provide `cvleft`/`cvright` environments so the side-bar/body widths stop
-      living in the user's `.tex`. Removes the "don't touch this if you don't
-      know what you're doing" warning from the README.
 - [ ] Rename the meaningless colours `yt` and `test` (they are the mail and site
       icon colours) — with backward-compatible aliases.
 - [ ] Document `\hlink` and `\capit` in the root README; they exist and are used

--- a/examples/example_cv.tex
+++ b/examples/example_cv.tex
@@ -35,10 +35,11 @@
 \begin{document}
   \makeprofile % Set header
 
-  % Set left and right part, don't custom 'textblock' and 'minipage'  commands and parameters if you don't know what you are doing
-  \begin{textblock}{20.5}(0.25, 3.5)
+  % cvbody / cvleft / cvright own the layout widths, so there is nothing here
+  % you need to keep in sync with the class.
+  \begin{cvbody}
 
-    \begin{minipage}[t]{0.37\textwidth}
+    \begin{cvleft}
 
       %%%%%%%%%%%%%%%%
       %%  Left bar  %%
@@ -64,7 +65,8 @@
 
       % Etc.
 
-    \end{minipage}\hfill\begin{minipage}[t]{0.61\textwidth}
+    \end{cvleft}
+    \begin{cvright}
 
       %%%%%%%%%%%%%%%%%%
       %%     Body     %%
@@ -98,8 +100,8 @@
 
       % Etc.
 
-    \end{minipage}
+    \end{cvright}
 
-  \end{textblock}
+  \end{cvbody}
 
 \end{document}


### PR DESCRIPTION
Two problems, one package.

**`\makeprofile` was copy-pasted into both classes** and the copies had already
drifted: the name column was `0.43\textwidth` in the CV and `0.45` in the letter.

**The side-bar and body widths lived in the document** while widths they had to
agree with lived in the class — the reason the README warned people off touching
them.

## What changed

`arthur-cv-header.sty`, required by both classes, holds the field declarations,
the contact column, the name column and the photo block. The four genuine
differences are parameters: the grey band (drawn by `arthur-cv` only), the
header-block width, the name-column width, and the `\cv@headerextra` hook.

The `0.43`/`0.45` drift is **preserved as data, not "fixed"** — changing either
number would move a real document.

The same package adds:

```latex
\begin{cvbody}                 % optional arg: vertical offset in cm (default 3.5)
  \begin{cvleft}  ... \end{cvleft}
  \begin{cvright} ... \end{cvright}
\end{cvbody}
```

which own `\cvleftwidth` and `\cvrightwidth`. The explicit `textblock`+`minipage`
form still works, so the examples now cover **both**: `example_cv.tex` uses the
environments, the three real CVs keep the explicit form.

## Verification

Byte-identical at 100 dpi across all six pages — including `example_cv.tex`
*after* converting it to the new environments. So: a pure refactor plus an
additive API.

## One trap, now commented in the `.sty`

The original had **two** space tokens between the contact and name minipages.
The row is set flush, so collapsing them to one shifts the name 2.69 pt left.
The first attempt did exactly that — the compile was clean and the pixel
comparison caught it. The trailing newlines in the two column macros are
load-bearing.

---
📚 4/6. Base: `feat/class-color-options`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)